### PR TITLE
Feat/user role

### DIFF
--- a/prisma/migrations/20250525120946_add_role_to_user/migration.sql
+++ b/prisma/migrations/20250525120946_add_role_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" TEXT NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,4 +20,5 @@ model User {
   nickname  String   @unique
   password  String
   createdAt DateTime @default(now())
+  role      String   @default("USER")
 }

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@prisma/client";
+import express from "express";
+import { AuthRequest, authToken } from "../middlewares/authMiddleware";
+import { isAdmin } from "../middlewares/adminMiddleware";
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+router.get("/users", authToken, isAdmin, async (req: AuthRequest, res) => {
+  try {
+    const users = await prisma.user.findMany({
+      select: {
+        id: true,
+        email: true,
+        nickname: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+    res.status(200).json(users);
+  } catch (err) {
+    return res.status(500).json({ message: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -23,4 +23,30 @@ router.get("/users", authToken, isAdmin, async (req: AuthRequest, res) => {
   }
 });
 
+router.delete(
+  "/users/:id",
+  authToken,
+  isAdmin,
+  async (req: AuthRequest, res) => {
+    const { id } = req.params;
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id: Number(id) },
+        select: { id: true, nickname: true, email: true },
+      });
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+      await prisma.user.delete({
+        where: { id: Number(id) },
+      });
+      return res
+        .status(200)
+        .json({ message: "User deleted successfully", user });
+    } catch (err) {
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  }
+);
+
 export default router;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -3,6 +3,7 @@ import express from "express";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { AuthRequest, authToken } from "../middlewares/authMiddleware";
+import { removeListener } from "process";
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -33,6 +34,7 @@ router.post("/signup", async (req, res) => {
         nickname,
         email,
         password: hashedPwd,
+        role: "USER", // Default role for new users
       },
     });
 
@@ -91,7 +93,7 @@ router.post("/login", async (req, res) => {
     }
 
     const token = jwt.sign(
-      { userId: user.id },
+      { userId: user.id, role: user.role },
       process.env.JWT_SECRET as string,
       { expiresIn: "7d" }
     );

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,10 @@
-import express from 'express';
-import authRouter from './auth';
+import express from "express";
+import authRouter from "./auth";
+import adminRouter from "./admin";
 
 const router = express.Router();
 
-router.use('/auth', authRouter);
+router.use("/auth", authRouter);
+router.use("admin", adminRouter);
 
 export default router;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,6 @@ import adminRouter from "./admin";
 const router = express.Router();
 
 router.use("/auth", authRouter);
-router.use("admin", adminRouter);
+router.use("/admin", adminRouter);
 
 export default router;

--- a/src/middlewares/adminMiddleware.ts
+++ b/src/middlewares/adminMiddleware.ts
@@ -1,0 +1,9 @@
+import { NextFunction, Response } from "express";
+import { AuthRequest } from "./authMiddleware";
+
+export const isAdmin = (req:AuthRequest,res:Response,next:NextFunction) => {
+    if (req.user?.role !== "ADMIN") {
+        return res.status(403).json({message:"Admin only"})
+    }
+    next();
+}

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 
 export interface AuthRequest extends Request {
-  user?: { userId: number };
+  user?: { userId: number; role?: string };
 }
 
 export const authToken = (

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 
 export interface AuthRequest extends Request {
-  user?: { userId: number; role?: string };
+  user?: { userId: number; role: string };
 }
 
 export const authToken = (
@@ -22,8 +22,9 @@ export const authToken = (
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as {
       userId: number;
+      role: string;
     };
-    req.user = { userId: decoded.userId };
+    req.user = { userId: decoded.userId, role: decoded.role };
     next();
   } catch (err) {
     return res.status(401).json({ message: "Invalid token" });


### PR DESCRIPTION
# Pull Request

## Description
- Added `role` field to the `User` model in `schema.prisma` with default value `"USER"`
- Created a new `adminMiddleware.ts` to protect admin-only routes based on JWT `role` field
- Implemented `admin.ts` route module containing:
  - `GET /api/v1/admin/users`: Retrieve all users (admin only)
  - `DELETE /api/v1/admin/users/:id`: Admin-only user deletion


## Why
These changes introduce a foundational access control system using roles, enabling the creation of an admin dashboard and protected features.  
Admins can now perform user management operations while general users are restricted from accessing sensitive endpoints.


## Testing
- Ran `npx prisma migrate dev --name add-role-to-user` to apply DB changes
- Verified role field defaults to `"USER"` when omitted
- Created an admin user manually and generated a JWT with `role: "ADMIN"`
- Accessed `/api/v1/admin/users` and `/api/v1/admin/users/:id` with:
  - ✅ Admin token → success
  - ❌ Regular user token → 403 Forbidden
- Tested behavior when deleting:
  - Valid user → 200 with user info
  - Invalid/nonexistent user → 404

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [x] I have updated documentation (if needed)
