### PR TITLE
🩹fix : fix incorrect usage of req.body in reset password routes

### DIFF
--- a/src/api/reset-password.ts
+++ b/src/api/reset-password.ts
@@ -8,7 +8,7 @@ const router = express.Router();
 const prisma = new PrismaClient();
 
 router.post("/", async (req, res) => {
-  const { email } = req.body();
+  const { email } = req.body;
 
   try {
     const user = await prisma.user.findUnique({
@@ -38,7 +38,7 @@ router.post("/", async (req, res) => {
 });
 
 router.post("/verify", async (req, res) => {
-  const { email, code } = req.body();
+  const { email, code } = req.body;
 
   try {
     const data = await prisma.passwordResetCode.findFirst({
@@ -62,7 +62,7 @@ router.post("/verify", async (req, res) => {
 });
 
 router.post("/update", async (req, res) => {
-  const { email, newPassword } = req.body();
+  const { email, newPassword } = req.body;
 
   try {
     const user = await prisma.user.findUnique({ where: { email } });


### PR DESCRIPTION
# Pull Request

## Description
- Fixed backend request parsing issue by correcting req.body( ) to req.body in API route handlers
- This correction was applied in the reset-password route to ensure proper parsing of request payloads

## Why
Incorrect usage of req.body( ) caused undefined values in API endpoints expecting POST data. This fix allows Express to correctly handle the request body and resolve the 404 or validation issues that arose due to missing input.

## Testing
- Ran the backend locally
- Sent POST requests to /api/v1/reset-password, /verify, and /update via frontend and Postman
- Verified req.body.email and other fields are correctly received
- Confirmed password reset flow works as expected after the fix

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #6 

## Checklist
- [ ] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
