### PR TITLE
♻️refactor : update refresh endpoint to retrieve refresh token from c…

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -186,7 +186,7 @@ router.post("/login", async (req, res) => {
 });
 
 router.post("/refresh", async (req, res) => {
-  const { refreshToken } = req.body;
+  const refreshToken = req.cookies.refreshToken;
 
   if (!refreshToken) {
     return res.status(400).json({ message: "Refresh token is required" });


### PR DESCRIPTION
# Pull Request

## Description
- Updated /refresh endpoint in the backend to securely retrieve the refresh token from httpOnly cookies instead of the request body
- Added proper validation and error handling for missing or invalid cookies
- Ensured consistency with login and logout routes that set and clear the refreshToken cookie

## Why
- Improves security by avoiding exposing refresh tokens in the request body
- Aligns with best practices for session management using httpOnly cookies
- Supports frontend logic that sends credentials (withCredentials: true) for automatic cookie handling

## Testing
- Started backend server
- Verified login sets refreshToken as an httpOnly cookie
- Called /refresh with a valid cookie and confirmed new access token is returned
- Tested expiration and logout scenarios where the cookie is invalid or cleared

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #8 

## Checklist
- [ ] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
