### PR TITLE
Feat/bookmark

### DIFF
--- a/src/api/bookmark.ts
+++ b/src/api/bookmark.ts
@@ -1,0 +1,108 @@
+import { PrismaClient } from "@prisma/client";
+import express from "express";
+import { AuthRequest, authToken } from "../middlewares/authMiddleware";
+import { asyncHandler } from "../utils/asyncHandler";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.post(
+  "/",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { lodgeId } = req.body;
+    const userId = req.user?.userId;
+
+    if (!lodgeId || !userId) {
+      return res
+        .status(400)
+        .json({ message: "Lodge ID and User ID are required" });
+    }
+
+    try {
+      const existingBookmark = await prisma.hotSpringLodgeBookmark.findFirst({
+        where: {
+          userId: Number(userId),
+          lodgeId: Number(lodgeId),
+        },
+      });
+
+      if (existingBookmark) {
+        return res.status(409).json({ message: "Bookmark already exists" });
+      }
+
+      const bookmark = await prisma.hotSpringLodgeBookmark.create({
+        data: {
+          userId: Number(userId),
+          lodgeId: Number(lodgeId),
+        },
+      });
+
+      return res.status(201).json(bookmark);
+    } catch (error) {
+      return res.status(500).json({ message: "Error creating bookmark" });
+    }
+  })
+);
+
+router.delete(
+  "/:lodgeId",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { lodgeId } = req.params;
+    const userId = req.user?.userId;
+
+    if (!lodgeId || !userId) {
+      return res
+        .status(400)
+        .json({ message: "Lodge ID and User ID are required" });
+    }
+
+    try {
+      const deleted = await prisma.hotSpringLodgeBookmark.deleteMany({
+        where: {
+          lodgeId: Number(lodgeId),
+          userId: Number(userId),
+        },
+      });
+
+      if (deleted.count === 0) {
+        return res.status(404).json({ message: "Bookmark not found" });
+      }
+
+      return res.status(200).json({ message: "Bookmark deleted successfully" });
+    } catch (error) {
+      return res.status(500).json({ message: "Error deleting bookmark" });
+    }
+  })
+);
+
+router.get(
+  "/",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      return res.status(400).json({ message: "User ID is required" });
+    }
+
+    try {
+      const bookmarks = await prisma.hotSpringLodgeBookmark.findMany({
+        where: {
+          userId: Number(userId),
+        },
+        include: { lodge: true },
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
+
+      return res.status(200).json(bookmarks);
+    } catch (error) {
+      return res.status(500).json({ message: "Error fetching bookmarks" });
+    }
+  })
+);
+
+export default router;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ import reviewRouter from "./review";
 import lodgeRouter from "./lodge";
 import reservationRouter from "./reservation";
 import priceRouter from "./price";
+import bookmarkRouter from "./bookmark";
 
 const router = express.Router();
 
@@ -20,5 +21,6 @@ router.use("/review", reviewRouter);
 router.use("/lodge", lodgeRouter);
 router.use("/reservation", reservationRouter);
 router.use("/price", priceRouter);
+router.use("/bookmark", bookmarkRouter);
 
 export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Implemented bookmark-related endpoints in the Express backend using Prisma
- Added POST /v1/bookmarks to allow authenticated users to add a bookmark for a lodge
- Added DELETE /v1/bookmarks/:lodgeId to allow users to remove a bookmark by lodgeId
- Added GET /v1/bookmarks to return all bookmarks for the authenticated user, including lodge details
- Ensured proper authentication middleware usage to restrict access to logged-in users only


## Why
- These changes provide essential backend support for bookmarking functionality
- Users need to save lodges they’re interested in for easy access later
- Providing dedicated bookmark endpoints enables seamless integration with the frontend
- Including lodge details in the GET response improves UX by reducing frontend calls


## Testing
- Ran the server locally
- Used Postman to test:
  - Adding a bookmark with valid user token
  - Preventing duplicate bookmarks (returns 409)
  - Deleting a bookmark by lodgeId
  - Retrieving all bookmarks for a user with lodge details included
  - Verified authentication middleware blocks unauthenticated access
- Checked logs for errors and fixed any Prisma validation issues


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
