### PR TITLE
Feat/review

### DIFF
--- a/prisma/migrations/20250702050026_change_relationship_between_report_review_and_lodge_review_tables/migration.sql
+++ b/prisma/migrations/20250702050026_change_relationship_between_report_review_and_lodge_review_tables/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "ReportReview" DROP CONSTRAINT "ReportReview_reviewId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ReportReview" ADD CONSTRAINT "ReportReview_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "HotSpringLodgeReview"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -221,6 +221,6 @@ model ReportReview {
   reason    String
   createdAt DateTime @default(now())
 
-  review HotSpringLodgeReview @relation(fields: [reviewId], references: [id])
+  review HotSpringLodgeReview @relation(fields: [reviewId], references: [id], onDelete: Cascade)
   user   User                 @relation(fields: [userId], references: [id])
 }


### PR DESCRIPTION
# Pull Request

## Description
- Refactored admin/reports.ts backend route to split deletion actions:
  - Added DELETE /report-only/:reviewId endpoint to remove only the report records without touching the review itself.
  - Added DELETE /review-only/:reviewId endpoint to remove only the review even if it has reports.
- Updated Prisma schema to enforce onDelete: Cascade relation between ReportReview and HotSpringLodgeReview.
  - Ensures that when a review is deleted, all related reports are also automatically deleted.

## Why
- Prevented foreign key constraint violations (500 errors) when deleting a review with related reports.
- Improved admin flexibility by allowing:
  - Deleting only the report (mark as resolved without removing the review).
  - Deleting only the review (even if it has associated reports).
- Simplified database integrity management with automatic cascading deletes in Prisma.

## Testing
- Updated Prisma schema with onDelete: Cascade and ran migration
- Verified the following in local dev:
  - Deleting a review via /review-only/:reviewId also removed its associated ReportReview entries automatically.
  - Deleting a report via /report-only/:reviewId left the HotSpringLodgeReview intact.
  - The /admin/reports listing reflects updated state after deletes.
- Used Postman to call all new and existing endpoints.


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #15 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
