### PR TITLE
♻️ refactor: enhance lodge deletion process by removing related roomT…

### DIFF
--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -513,6 +513,10 @@ router.delete("/:id", (async (req, res) => {
       )
     );
 
+    await prisma.roomTypeImage.deleteMany({
+      where: { roomTypeId: { in: roomTypeIds } },
+    })
+
     await prisma.seasonalPricing.deleteMany({
       where: { roomTypeId: { in: roomTypeIds } },
     });
@@ -526,6 +530,22 @@ router.delete("/:id", (async (req, res) => {
     });
 
     await prisma.hotSpringLodgeImage.deleteMany({
+      where: { lodgeId: Number(id) },
+    });
+
+    await prisma.reservation.deleteMany({
+      where: { lodgeId: Number(id) },
+    });
+
+    await prisma.hotSpringLodgeBookmark.deleteMany({
+      where: { lodgeId: Number(id) },
+    });
+
+    await prisma.hotSpringLodgeDetail.deleteMany({
+      where: { lodgeId: Number(id) },
+    });
+
+    await prisma.hotSpringLodgeReview.deleteMany({
       where: { lodgeId: Number(id) },
     });
 


### PR DESCRIPTION
# Pull Request

## Description
- Refactored the admin lodge DELETE API route
- Enforced proper foreign key deletion order
- Added explicit deletion of dependent RoomTypeImage records before RoomType
- Ensured all related records (Reservation, RoomInventory, SeasonalPricing, RoomTypeImage, RoomType, HotSpringLodgeImage, HotSpringLodgeBookmark, HotSpringLodgeDetail, HotSpringLodgeReview) are removed before deleting the HotSpringLodge itself


## Why
- Prevented `PrismaClientKnownRequestError` caused by foreign key constraint violations
- Fixed 500 Internal Server Error when deleting lodges with associated room types and images
- Improved reliability and correctness of the admin lodge deletion workflow


## Testing
- Ran the server locally
- Verified DELETE `/api/v1/admin/lodge/:id` succeeds without 500 errors for lodges with dependent records
- Confirmed all related database entries are removed (including RoomTypeImages, RoomInventory, etc.)
- Checked Prisma logs for absence of FK constraint errors

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #15 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
