### PR TITLE
♻️ refactor: update reservation retrieval to exclude cancelled reserv…

### DIFF
--- a/src/api/reservation.ts
+++ b/src/api/reservation.ts
@@ -314,6 +314,10 @@ router.get("/", authToken, async (req: AuthRequest, res) => {
     const reservations = await prisma.reservation.findMany({
       where: {
         userId: userId ? Number(userId) : undefined,
+        OR : [
+          {status: {not:"CANCELLED"}},
+          {AND: [{status: "CANCELLED"},{cancelReason: {not: "AUTO_EXPIRED"}}]}
+        ]
       },
       include: {
         lodge: true,


### PR DESCRIPTION
# Pull Request

## Description
- Updated the GET `/v1/reservation` endpoint in `reservation.ts`
- Added a filter to exclude reservations with status `CANCELLED` *and* `cancelReason` equal to `AUTO_EXPIRED`
- Ensures frontend "예약취소" tab does not display auto-expired cancellations


## Why
Previously, all cancelled reservations were returned, including system-expired (`AUTO_EXPIRED`) reservations.  
This cluttered the user's cancelled list with expired reservations they didn't cancel manually.  
This change improves user experience by showing only user-requested or admin-forced cancellations.


## Testing
- Ran the backend server locally
- Created test reservations with different statuses and cancelReasons
- Verified GET `/v1/reservation` no longer returns CANCELLED reservations with `cancelReason` = `AUTO_EXPIRED`
- Confirmed frontend reservation list filtered as expected

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #36 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
