### PR TITLE
Feat/reservation

### DIFF
--- a/src/api/reservation.ts
+++ b/src/api/reservation.ts
@@ -261,6 +261,15 @@ router.patch(
           throw new Error("Reservation not found");
         }
 
+        const previousStatus = reservation.status;
+
+        const updated = await tx.reservation.update({
+          where: { id: reservationId },
+          data: { status: "CANCELLED",
+            cancelReason: cancelReason
+           },
+        });
+        
         if (
           reservation.status === "CONFIRMED" &&
           (cancelReason === "USER_REQUESTED" || cancelReason === "ADMIN_FORCED")
@@ -291,12 +300,6 @@ router.patch(
           );
         }
 
-        const updated = await tx.reservation.update({
-          where: { id: reservationId },
-          data: { status: "CANCELLED",
-            cancelReason: cancelReason
-           },
-        });
 
         return updated;
       });

--- a/src/api/reservation.ts
+++ b/src/api/reservation.ts
@@ -293,7 +293,9 @@ router.patch(
 
         const updated = await tx.reservation.update({
           where: { id: reservationId },
-          data: { status: "CANCELLED" },
+          data: { status: "CANCELLED",
+            cancelReason: cancelReason
+           },
         });
 
         return updated;
@@ -337,5 +339,7 @@ router.get("/", authToken, async (req: AuthRequest, res) => {
     res.status(500).json({ message: "Internal server error" });
   }
 });
+
+
 
 export default router;

--- a/src/api/reservation.ts
+++ b/src/api/reservation.ts
@@ -287,7 +287,10 @@ router.patch(
                 where: {
                   lodgeId: reservation.lodgeId,
                   roomTypeId: reservation.roomTypeId,
-                  date,
+                  date: {
+                    gte: startOfDay(date),
+                    lt: startOfDay(addDays(date, 1)),
+                  },
                 },
                 data: {
                   availableRooms: {


### PR DESCRIPTION
# Pull Request

## Description
- Fixed backend cancellation route to correctly recover availableRooms in RoomInventory.
- Ensured that when a CONFIRMED reservation is cancelled by USER_REQUESTED or ADMIN_FORCED, the room count is properly added back to inventory for each reserved date.
- Updated the SQL WHERE condition to match dates accurately using startOfDay range, avoiding issues with DateTime precision.


## Why
Previously, cancelling a CONFIRMED reservation did not restore the availableRooms in the roomInventory table because of an incorrect date matching query. This fix ensures that rooms become available for other users after a valid cancellation.


## Testing
- Ran server locally
- Created a reservation and confirmed it to decrement inventory
- Cancelled the reservation (USER_REQUESTED)
- Verified that availableRooms in roomInventory increased by the correct room count for each date
- Checked DB to confirm correct inventory update

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #37 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
