### PR TITLE
Feat/admin

### DIFF
--- a/src/api/admin/user.ts
+++ b/src/api/admin/user.ts
@@ -6,9 +6,80 @@ import { asyncHandler } from "../../utils/asyncHandler";
 const prisma = new PrismaClient();
 const router = express.Router();
 
-router.get("/", asyncHandler(async (_, res) => {
-  try {
-    const users = await prisma.user.findMany({
+router.get(
+  "/",
+  asyncHandler(async (_, res) => {
+    try {
+      const users = await prisma.user.findMany({
+        select: {
+          id: true,
+          email: true,
+          nickname: true,
+          role: true,
+          createdAt: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
+      res.status(200).json(users);
+    } catch (err) {
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
+
+router.delete(
+  "/:id",
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { id } = req.params;
+    const userId = Number(id);
+
+    if (isNaN(userId)) {
+      return res.status(400).json({ message: "Invalid user ID" });
+    }
+
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, nickname: true, email: true },
+      });
+
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      await prisma.user.delete({
+        where: { id: userId },
+      });
+
+      return res
+        .status(200)
+        .json({ message: "User deleted successfully", user });
+    } catch (err) {
+      return res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
+
+router.patch(
+  "/:id/role",
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { id } = req.params;
+    const userId = Number(id);
+    const { role } = req.body;
+
+    if (isNaN(userId)) {
+      return res.status(400).json({ message: "Invalid user ID" });
+    }
+
+    if (typeof role !== "string" || !["USER", "ADMIN"].includes(role)) {
+      return res.status(400).json({ message: "Invalid role" });
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: { role },
       select: {
         id: true,
         email: true,
@@ -16,42 +87,12 @@ router.get("/", asyncHandler(async (_, res) => {
         role: true,
         createdAt: true,
       },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
-    res.status(200).json(users);
-  } catch (err) {
-    return res.status(500).json({ message: "Internal server error" });
-  }
-}));
-
-router.delete("/:id", asyncHandler(async (req: AuthRequest, res) => {
-  const { id } = req.params;
-  const userId = Number(id)
-
-  if(isNaN(userId)) {
-    return res.status(400).json({ message: "Invalid user ID" });
-  }
-
-  try {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { id: true, nickname: true, email: true },
     });
 
-    if (!user) {
-      return res.status(404).json({ message: "User not found" });
-    }
-
-    await prisma.user.delete({
-      where: { id: userId },
-    });
-
-    return res.status(200).json({ message: "User deleted successfully", user });
-  } catch (err) {
-    return res.status(500).json({ message: "Internal server error" });
-  }
-}));
+    return res
+      .status(200)
+      .json({ message: "User role updated successfully", user: updatedUser });
+  })
+);
 
 export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Added PATCH endpoint in /admin/user.ts for updating a user's role
- Validates user ID and role value (USER or ADMIN)
- Uses Prisma to update the user's role in the database
- Returns the updated user object in the response

## Why
- Allows admins to change a user's role from USER to ADMIN or vice versa
- Supports management of user permissions via the admin panel
- Essential for implementing role-based access control in the app

## Testing
- Ran the server locally
- Used Postman to send PATCH requests to /api/v1/admin/user/:id/role
  - Example body: { "role": "ADMIN" }
  - Confirmed role updated correctly in DB
  - Verified 400 response on invalid ID or role
- Checked updated user returned in response

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #39 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
