### PR TITLE
Feat/admin

### DIFF
--- a/src/api/admin/user.ts
+++ b/src/api/admin/user.ts
@@ -95,4 +95,50 @@ router.patch(
   })
 );
 
+router.get(
+  "/:id/reservations",
+  asyncHandler(async (req: AuthRequest, res) => {
+    const userId = Number(req.params.id);
+
+    if (isNaN(userId)) {
+      return res.status(400).json({ message: "Invalid user ID" });
+    }
+
+    const reservations = await prisma.reservation.findMany({
+      where: { userId },
+      include: {
+        lodge: true,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    return res.status(200).json(reservations);
+  })
+);
+
+router.get(
+  "/:id/reviews",
+  asyncHandler(async (req: AuthRequest, res) => {
+    const userId = Number(req.params.id);
+
+    if (isNaN(userId)) {
+      return res.status(400).json({ message: "Invalid user ID" });
+    }
+
+    const reviews = await prisma.hotSpringLodgeReview.findMany({
+      where: { userId },
+      include: {
+        lodge: true,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    return res.status(200).json(reviews);
+  })
+);
+
 export default router;

--- a/src/api/admin/user.ts
+++ b/src/api/admin/user.ts
@@ -104,6 +104,14 @@ router.get(
       return res.status(400).json({ message: "Invalid user ID" });
     }
 
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 10;
+    const skip = (page - 1) * limit;
+
+    const total = await prisma.reservation.count({
+      where: { userId },
+    });
+
     const reservations = await prisma.reservation.findMany({
       where: { userId },
       include: {
@@ -112,9 +120,11 @@ router.get(
       orderBy: {
         createdAt: "desc",
       },
+      skip,
+      take: limit,
     });
 
-    return res.status(200).json(reservations);
+    return res.status(200).json({ data: reservations, total, page, limit });
   })
 );
 
@@ -127,6 +137,14 @@ router.get(
       return res.status(400).json({ message: "Invalid user ID" });
     }
 
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 10;
+    const skip = (page - 1) * limit;
+
+    const total = await prisma.hotSpringLodgeReview.count({
+      where: { userId },
+    });
+
     const reviews = await prisma.hotSpringLodgeReview.findMany({
       where: { userId },
       include: {
@@ -135,9 +153,11 @@ router.get(
       orderBy: {
         createdAt: "desc",
       },
+      skip,
+      take: limit,
     });
 
-    return res.status(200).json(reviews);
+    return res.status(200).json({ data: reviews, total, page, limit });
   })
 );
 

--- a/src/api/admin/user.ts
+++ b/src/api/admin/user.ts
@@ -104,25 +104,26 @@ router.get(
       return res.status(400).json({ message: "Invalid user ID" });
     }
 
-    const page = Number(req.query.page) || 1;
-    const limit = Number(req.query.limit) || 10;
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 10;
     const skip = (page - 1) * limit;
 
-    const total = await prisma.reservation.count({
-      where: { userId },
-    });
-
-    const reservations = await prisma.reservation.findMany({
-      where: { userId },
-      include: {
-        lodge: true,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-      skip,
-      take: limit,
-    });
+    const [reservations, total] = await Promise.all([
+      prisma.reservation.findMany({
+        where: { userId },
+        include: {
+          lodge: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+        skip,
+        take: limit,
+      }),
+      prisma.reservation.count({
+        where: { userId },
+      }),
+    ]);
 
     return res.status(200).json({ data: reservations, total, page, limit });
   })
@@ -137,25 +138,26 @@ router.get(
       return res.status(400).json({ message: "Invalid user ID" });
     }
 
-    const page = Number(req.query.page) || 1;
-    const limit = Number(req.query.limit) || 10;
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 10;
     const skip = (page - 1) * limit;
 
-    const total = await prisma.hotSpringLodgeReview.count({
-      where: { userId },
-    });
-
-    const reviews = await prisma.hotSpringLodgeReview.findMany({
-      where: { userId },
-      include: {
-        lodge: true,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-      skip,
-      take: limit,
-    });
+    const [reviews,total] = await Promise.all([
+      prisma.hotSpringLodgeReview.findMany({
+        where: { userId },
+        include: {
+          lodge: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+        skip,
+        take: limit,
+      }),
+      prisma.hotSpringLodgeReview.count({
+        where: { userId },
+      }),
+    ]);
 
     return res.status(200).json({ data: reviews, total, page, limit });
   })


### PR DESCRIPTION
# Pull Request

## Description
- Implemented admin endpoints to fetch a user's reservations and reviews
- Added pagination support (page, limit) to these endpoints in the backend
- Updated Prisma queries to use skip and take for pagination
- Adjusted backend responses to include total count, page, and limit
- Enables admin frontend to request paged data for user reservations and reviews


## Why
- Without pagination, the admin dashboard could become slow or unmanageable with many records
- Pagination improves performance and usability when browsing a user's reservations and reviews
- Provides consistent, scalable API responses for admin management tools


## Testing
- Ran server locally and hit new endpoints with Postman using various page and limit params
- Verified that skip/take work as expected in Prisma queries
- Confirmed responses include correct page, limit, total, and paged data
- Connected with frontend admin user detail page and ensured pagination buttons fetch correct data


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #40 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
