### PR TITLE
Feat/ticket

### DIFF
--- a/prisma/migrations/20250711055339_add_total_adult_ticket_and_total_children_ticket_in_ticket_inventory_table/migration.sql
+++ b/prisma/migrations/20250711055339_add_total_adult_ticket_and_total_children_ticket_in_ticket_inventory_table/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `availableTickets` on the `TicketInventory` table. All the data in the column will be lost.
+  - You are about to drop the column `totalTickets` on the `TicketInventory` table. All the data in the column will be lost.
+  - You are about to drop the column `totalTickets` on the `TicketType` table. All the data in the column will be lost.
+  - Added the required column `availableAdultTickets` to the `TicketInventory` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `availableChildTickets` to the `TicketInventory` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `totalAdultTickets` to the `TicketInventory` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `totalChildTickets` to the `TicketInventory` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `totalAdultTickets` to the `TicketType` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `totalChildTickets` to the `TicketType` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "TicketInventory" DROP COLUMN "availableTickets",
+DROP COLUMN "totalTickets",
+ADD COLUMN     "availableAdultTickets" INTEGER NOT NULL,
+ADD COLUMN     "availableChildTickets" INTEGER NOT NULL,
+ADD COLUMN     "totalAdultTickets" INTEGER NOT NULL,
+ADD COLUMN     "totalChildTickets" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "TicketType" DROP COLUMN "totalTickets",
+ADD COLUMN     "totalAdultTickets" INTEGER NOT NULL,
+ADD COLUMN     "totalChildTickets" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -240,14 +240,15 @@ model ReportReview {
 }
 
 model TicketType {
-  id           Int      @id @default(autoincrement())
-  lodgeId      Int
-  name         String
-  description  String?
-  adultPrice   Int
-  childPrice   Int
-  totalTickets Int
-  createdAt    DateTime @default(now())
+  id                Int      @id @default(autoincrement())
+  lodgeId           Int
+  name              String
+  description       String?
+  adultPrice        Int
+  childPrice        Int
+  totalAdultTickets Int
+  totalChildTickets Int
+  createdAt         DateTime @default(now())
 
   lodge HotSpringLodge @relation(fields: [lodgeId], references: [id])
 
@@ -258,12 +259,14 @@ model TicketType {
 }
 
 model TicketInventory {
-  id               Int      @id @default(autoincrement())
-  lodgeId          Int
-  ticketTypeId     Int
-  date             DateTime
-  totalTickets     Int
-  availableTickets Int
+  id                    Int      @id @default(autoincrement())
+  lodgeId               Int
+  ticketTypeId          Int
+  date                  DateTime
+  totalAdultTickets     Int
+  totalChildTickets     Int
+  availableAdultTickets Int
+  availableChildTickets Int
 
   ticketType TicketType     @relation(fields: [ticketTypeId], references: [id])
   lodge      HotSpringLodge @relation(fields: [lodgeId], references: [id])

--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -11,7 +11,8 @@ interface TicketInput {
   description?: string;
   adultPrice: number;
   childPrice: number;
-  totalTickets: number;
+  totalAdultTickets: number;
+  totalChildTickets: number;
 }
 
 const router = express.Router();
@@ -189,7 +190,8 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
                 description: ticket.description,
                 adultPrice: ticket.adultPrice,
                 childPrice: ticket.childPrice,
-                totalTickets: ticket.totalTickets,
+                totalAdultTickets: ticket.totalAdultTickets,
+                totalChildTickets: ticket.totalChildTickets,
               },
             });
 
@@ -206,8 +208,10 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
                 lodgeId: lodge.id,
                 ticketTypeId: newTicketType.id,
                 date,
-                totalTickets: ticket.totalTickets,
-                availableTickets: ticket.totalTickets,
+                totalAdultTickets: ticket.totalAdultTickets,
+                totalChildTickets: ticket.totalChildTickets,
+                availableAdultTickets: ticket.totalAdultTickets,
+                availableChildTickets: ticket.totalChildTickets,
               })),
             });
 
@@ -598,8 +602,10 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
                 lodgeId: updated.id,
                 ticketTypeId: ticket.id!,
                 date,
-                totalTickets: ticket.totalTickets,
-                availableTickets: ticket.totalTickets,
+                totalAdultTickets: ticket.totalAdultTickets,
+                totalChildTickets: ticket.totalChildTickets,
+                availableAdultTickets: ticket.totalAdultTickets,
+                availableChildTickets: ticket.totalChildTickets,
               })),
             });
           } else {
@@ -610,7 +616,8 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
                 description: ticket.description,
                 adultPrice: ticket.adultPrice,
                 childPrice: ticket.childPrice,
-                totalTickets: ticket.totalTickets,
+                totalAdultTickets: ticket.totalAdultTickets,
+                totalChildTickets: ticket.totalChildTickets,
               },
             });
 
@@ -626,8 +633,10 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
               data: dates.map((date) => ({
                 ticketTypeId: newTicket.id,
                 date,
-                totalTickets: ticket.totalTickets,
-                availableTickets: ticket.totalTickets,
+                totalAdultTickets: ticket.totalAdultTickets,
+                totalChildTickets: ticket.totalChildTickets,
+                availableAdultTickets: ticket.totalAdultTickets,
+                availableChildTickets: ticket.totalChildTickets,
                 lodgeId: updated.id,
               })),
             });


### PR DESCRIPTION
# Pull Request

## Description
- Updated Prisma schema to support adult/child ticket counts and prices
- Added totalAdultTickets, totalChildTickets, availableAdultTickets, availableChildTickets to TicketInventory
- Added totalAdultTickets, totalChildTickets to TicketType
- Regenerated Prisma client after schema change
- Created new migration with default values to support existing data

## Why
- To allow separate tracking of adult and child ticket availability and pricing
- Supports more flexible ticket booking logic in the future
- Solves need for differentiated inventory for adults and children

## Testing
- Ran npx prisma migrate dev with default values to update existing rows
- Verified schema changes via Prisma Studio
- Confirmed Prisma client builds without errors
- Checked that new reservations and inventories can store adult/child ticket counts

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #47 

## Checklist
- [x] Code builds and runs locally
- [ ] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
