### PR TITLE
Feat/ticket

### DIFF
--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -613,6 +613,8 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
                 description: ticket.description,
                 adultPrice: ticket.adultPrice,
                 childPrice: ticket.childPrice,
+                totalAdultTickets: ticket.totalAdultTickets,
+                totalChildTickets: ticket.totalChildTickets,
               },
             });
 


### PR DESCRIPTION
# Pull Request

## Description
- Refactored the `PATCH /lodge/:id` backend route
- Added logic to update `availableRooms` in `roomInventory` when `totalRooms` changes
- Added logic to update `availableAdultTickets` and `availableChildTickets` in `ticketInventory` when total ticket counts change
- Cleaned up transaction structure for clarity

## Why
- Previously, changing `totalRooms` or ticket totals only updated the schema, not the available inventory
- This caused inconsistencies where existing reservations were not correctly reflected in availability
- The refactor ensures that availability is recalculated based on existing reservations after updates, maintaining data integrity


## Testing
- Ran the server locally
- Tested PATCH requests in Postman with different room and ticket totals
- Verified:
  - Existing reservations remain unaffected
  - Available room and ticket counts adjust correctly based on new total values minus reserved counts
  - No errors on edge cases with 0 or high totals


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #48 

## Checklist
- [x] Code builds and runs locally
- [ ] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
