### PR TITLE
✨ feat: add ticket report handling routes for fetching, deleting, and…

### DIFF
--- a/src/api/admin/ticketReports.ts
+++ b/src/api/admin/ticketReports.ts
@@ -1,0 +1,124 @@
+import { PrismaClient } from "@prisma/client";
+import express from "express";
+import { asyncHandler } from "../../utils/asyncHandler";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 10;
+    const skip = (page - 1) * limit;
+
+    try {
+      const [reported, total] = await prisma.$transaction([
+        prisma.ticketReportReview.findMany({
+          include: {
+            review: {
+              include: {
+                ticketType: true,
+                user: true,
+              },
+            },
+            user: true,
+          },
+          orderBy: { createdAt: "desc" },
+          skip,
+          take: limit,
+        }),
+        prisma.ticketReportReview.count(),
+      ]);
+
+      res.status(200).json({
+        data: reported,
+        total,
+        page,
+        limit,
+      });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
+
+router.delete(
+  "/report-only/:reviewId",
+  asyncHandler(async (req, res) => {
+    const { reviewId } = req.params;
+
+    try {
+      await prisma.ticketReportReview.deleteMany({
+        where: { reviewId: Number(reviewId) },
+      });
+
+      res.status(200).json({
+        message: "Ticket review reports deleted successfully",
+        reviewId: Number(reviewId),
+      });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
+
+router.patch(
+  "/review/:reviewId/hide",
+  asyncHandler(async (req, res) => {
+    const { reviewId } = req.params;
+    const { isHidden } = req.body;
+
+    if (typeof isHidden !== "boolean") {
+      return res.status(400).json({ message: "isHidden must be a boolean" });
+    }
+
+    try {
+      const updated = await prisma.ticketReview.update({
+        where: { id: Number(reviewId) },
+        data: { isHidden },
+      });
+
+      res.status(200).json({
+        message: "Ticket review hide status updated",
+        updated,
+      });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
+
+router.delete(
+  "/review-only/:reviewId",
+  asyncHandler(async (req, res) => {
+    const { reviewId } = req.params;
+
+    try {
+      const existingReview = await prisma.ticketReview.findUnique({
+        where: { id: Number(reviewId) },
+      });
+
+      if (!existingReview) {
+        return res.status(404).json({ message: "Ticket review not found" });
+      }
+
+      await prisma.ticketReview.delete({
+        where: { id: Number(reviewId) },
+      });
+
+      res.status(200).json({
+        message: "Ticket review deleted successfully",
+        reviewId: Number(reviewId),
+      });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
+
+export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Added Express routes for managing Ticket Review Reports in the admin backend
- Created endpoints to:
  - List reported ticket reviews with pagination
  - Delete only ticket review reports (resolve reports)
  - Hide or unhide ticket reviews
  - Delete ticket reviews entirely (including associated reports via cascade)
- Used Prisma to interact with TicketReview and TicketReportReview models


## Why
- To provide admins with tools to manage user-reported content for ticket reviews
- Enable moderation of inappropriate or flagged reviews in the ticket system
- Maintain platform quality and user trust by supporting content moderation


## Testing
- Ran the server locally and verified all new endpoints via Postman:
  - `GET /admin/ticket-reports` returns paginated reports
  - `DELETE /admin/ticket-reports/report-only/:reviewId` deletes only the reports
  - `PATCH /admin/ticket-reports/review/:reviewId/hide` updates isHidden field
  - `DELETE /admin/ticket-reports/review-only/:reviewId` removes the review entirely
- Checked that Prisma properly cascades deletes for related reports
- Verified DB changes in local development environment


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #49 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
