### PR TITLE
Feat/ticket

### DIFF
--- a/src/api/admin/index.ts
+++ b/src/api/admin/index.ts
@@ -7,6 +7,8 @@ import reportsRouter from "./reports";
 import reservationRouter from "./reservation";
 import { authToken } from "../../middlewares/authMiddleware";
 import { isAdmin } from "../../middlewares/adminMiddleware";
+import ticketReportsRouter from "./ticketReports";
+import ticketReservationRouter from "./ticketReservation";
 
 const router = express.Router();
 
@@ -18,5 +20,7 @@ router.use("/room-type", roomTypeRouter);
 router.use("/room-inventory", roomInventoryRouter);
 router.use("/reports",reportsRouter);
 router.use("/reservation", reservationRouter);
+router.use("/ticket-reports", ticketReportsRouter);
+router.use("/ticket-reservation", ticketReservationRouter);
 
 export default router;

--- a/src/api/admin/ticketReservation.ts
+++ b/src/api/admin/ticketReservation.ts
@@ -1,0 +1,135 @@
+import { CancelReason, PrismaClient, ReservationStatus } from "@prisma/client";
+import express from "express";
+import { asyncHandler } from "../../utils/asyncHandler";
+import { startOfDay, addDays } from "date-fns";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 10;
+    const skip = (page - 1) * limit;
+
+    const [reservations, total] = await prisma.$transaction([
+      prisma.ticketReservation.findMany({
+        include: {
+          ticketType: true,
+          user: {
+            select: {
+              id: true,
+              nickname: true,
+              email: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+      }),
+      prisma.ticketReservation.count(),
+    ]);
+
+    res.status(200).json({ data: reservations, total, page, limit });
+  })
+);
+
+router.get(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const reservation = await prisma.ticketReservation.findUnique({
+      where: { id: Number(req.params.id) },
+      include: {
+        ticketType: true,
+        user: {
+          select: {
+            id: true,
+            nickname: true,
+            email: true,
+          },
+        },
+      },
+    });
+    if (!reservation) {
+      return res.status(404).json({ message: "Reservation not found" });
+    }
+    res.status(200).json(reservation);
+  })
+);
+
+router.patch(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const { status, cancelReason } = req.body;
+    const reservationId = Number(req.params.id);
+
+    if (!status) {
+      return res.status(400).json({ message: "Status is required" });
+    }
+
+    if (!Object.values(ReservationStatus).includes(status)) {
+      return res.status(400).json({ message: "Invalid status" });
+    }
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const reservation = await tx.ticketReservation.findUnique({
+        where: { id: reservationId },
+      });
+
+      if (!reservation) {
+        throw new Error("Reservation not found");
+      }
+
+      const previousStatus = reservation.status;
+
+      const newReservation = await tx.ticketReservation.update({
+        where: { id: reservationId },
+        data: {
+          status,
+          cancelReason:
+            status === ReservationStatus.CANCELLED
+              ? (cancelReason as CancelReason) || CancelReason.ADMIN_FORCED
+              : null,
+        },
+      });
+
+      if (
+        previousStatus === ReservationStatus.CONFIRMED &&
+        newReservation.status === ReservationStatus.CANCELLED &&
+        (newReservation.cancelReason === CancelReason.USER_REQUESTED ||
+          newReservation.cancelReason === CancelReason.ADMIN_FORCED)
+      ) {
+        await tx.ticketInventory.updateMany({
+          where: {
+            lodgeId: reservation.ticketTypeId
+              ? (await tx.ticketType.findUnique({
+                  where: { id: reservation.ticketTypeId },
+                }))?.lodgeId
+              : undefined,
+            ticketTypeId: reservation.ticketTypeId,
+            date: {
+              gte: startOfDay(reservation.date),
+              lt: startOfDay(addDays(reservation.date, 1)),
+            },
+          },
+          data: {
+            availableAdultTickets: {
+              increment: reservation.adults,
+            },
+            availableChildTickets: {
+              increment: reservation.children,
+            },
+          },
+        });
+      }
+
+      return newReservation;
+    });
+
+    res.status(200).json(updated);
+  })
+);
+
+export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Implemented admin API routes for managing **TicketReservation** records
- Added Express router for:
  - Listing ticket reservations with pagination
  - Retrieving a single ticket reservation by ID
  - Updating reservation status, including cancellation
- Integrated Prisma queries for TicketReservation model
- Included logic to restore available ticket inventory on admin-forced cancellations


## Why
- To allow admins to view and manage user ticket reservations in the system
- To enable status updates (e.g., approve or cancel) for ticket reservations
- To support inventory adjustment on cancellations, ensuring correct availability tracking


## Testing
- Ran the Express server locally
- Verified:
  - `GET /admin/ticket-reservations` returns paginated reservations
  - `GET /admin/ticket-reservations/:id` returns reservation details
  - `PATCH /admin/ticket-reservations/:id` updates reservation status and restores inventory if canceled
- Checked database changes using Prisma Studio
- Used Postman to send sample requests and confirm responses

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #49 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
