### PR TITLE
Feat/ticket

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,6 +11,7 @@ import priceRouter from "./price";
 import bookmarkRouter from "./bookmark";
 import reportReviewRouter from "./report-review";
 import userRouter from "./user";
+import ticketRouter from "./ticket";
 
 const router = express.Router();
 
@@ -26,5 +27,6 @@ router.use("/price", priceRouter);
 router.use("/bookmark", bookmarkRouter);
 router.use("/report-review", reportReviewRouter);
 router.use("/user",userRouter)
+router.use("/ticket", ticketRouter);
 
 export default router;

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -17,12 +17,21 @@ router.get(
     }
 
     const searchDate = new Date(String(date));
+    const startOfDay = new Date(searchDate);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(startOfDay);
+    endOfDay.setDate(endOfDay.getDate() + 1);
+
     const adultsNum = parseInt(String(adults)) || 1;
     const childrenNum = parseInt(String(children)) || 0;
 
     const inventories = await prisma.ticketInventory.findMany({
       where: {
-        date: searchDate,
+        date: {
+            gte: startOfDay,
+            lt: endOfDay,
+        },
         availableAdultTickets: {
           gte: adultsNum,
         },

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -1,0 +1,82 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+import { asyncHandler } from "../utils/asyncHandler";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.get(
+  "/search",
+  asyncHandler(async (req, res) => {
+    const { region, date, adults, children } = req.query;
+
+    if (!date || !adults) {
+      return res
+        .status(400)
+        .json({ message: "Missing required search parameters" });
+    }
+
+    const searchDate = new Date(String(date));
+    const adultsNum = parseInt(String(adults)) || 1;
+    const childrenNum = parseInt(String(children)) || 0;
+
+    const inventories = await prisma.ticketInventory.findMany({
+      where: {
+        date: searchDate,
+        availableAdultTickets: {
+          gte: adultsNum,
+        },
+        availableChildTickets: {
+          gte: childrenNum,
+        },
+        ticketType: {
+          lodge: {
+            address:
+              region && region !== "전체" && region !== "All"
+                ? {
+                    contains: String(region),
+                    mode: "insensitive",
+                  }
+                : undefined,
+          },
+        },
+      },
+      include: {
+        ticketType: {
+          include: {
+            lodge: true,
+          },
+        },
+      },
+    });
+
+    const ticketMap = new Map<number, any>();
+
+    inventories.forEach((inv) => {
+      const tt = inv.ticketType;
+      if (!ticketMap.has(tt.id)) {
+        ticketMap.set(tt.id, {
+          id: tt.id,
+          name: tt.name,
+          description: tt.description,
+          region: tt.lodge.address,
+          lodgeId: tt.lodgeId,
+          adultPrice: tt.adultPrice,
+          childPrice: tt.childPrice,
+          availableAdultTickets: 0,
+          availableChildTickets: 0,
+          date: searchDate,
+        });
+      }
+      const agg = ticketMap.get(tt.id);
+      agg.availableAdultTickets += inv.availableAdultTickets;
+      agg.availableChildTickets += inv.availableChildTickets;
+    });
+
+    const tickets = Array.from(ticketMap.values());
+
+    res.status(200).json(tickets);
+  })
+);
+
+export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Created a new `/ticket/search` endpoint in the Express backend.
- The endpoint allows clients to search for available ticket inventories by region, date, and number of adults/children.
- Includes logic to filter TicketInventory records by date range (day-level matching) and available ticket counts.
- Groups results by TicketType, aggregating available adult and child tickets.


## Why
- Enables the frontend to query available tickets for a specific date with accurate filtering by passenger counts.
- Supports separation of concerns between lodging and ticket reservation flows.
- Provides necessary data for the ticket listing page in the frontend, improving UX for users searching for hot spring ticket options.


## Testing
- Ran the Express server locally.
- Verified GET `/api/v1/ticket/search` with various query parameters using Postman.
- Confirmed correct filtering by region, date, adults, and children.
- Validated that results match the available inventory in the database.
- Checked edge cases for date filtering to ensure time component does not block day-level searches.


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #51 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
