### PR TITLE
Feat/ticket

### DIFF
--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -4,6 +4,7 @@ import multer from "multer";
 import { uploadToCloudinary } from "../../utils/uploadToCloudinary";
 import { v4 as uuidv4 } from "uuid";
 import { deleteFromCloudinary } from "../../utils/deleteFromCloudinary";
+import { startOfDay } from "date-fns";
 
 interface TicketInput {
   id?: number;
@@ -171,7 +172,7 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
           dates.map((date) => ({
             lodgeId: lodge.id,
             roomTypeId: roomType.id,
-            date,
+            date: startOfDay(date),
             totalRooms: roomType.totalRooms,
             availableRooms: roomType.totalRooms,
           }))
@@ -200,7 +201,7 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
             for (let i = 0; i < 365; i++) {
               const d = new Date(today);
               d.setDate(today.getDate() + i);
-              dates.push(d);
+              dates.push(startOfDay(d));
             }
 
             await tx.ticketInventory.createMany({

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,7 @@ import reportReviewRouter from "./report-review";
 import userRouter from "./user";
 import ticketRouter from "./ticket";
 import ticketBookmarkRouter from "./ticketBookmark";
+import ticketReservationRouter from "./ticket-reservation";
 
 const router = express.Router();
 
@@ -30,5 +31,6 @@ router.use("/report-review", reportReviewRouter);
 router.use("/user", userRouter);
 router.use("/ticket", ticketRouter);
 router.use("/ticket-bookmark", ticketBookmarkRouter);
+router.use("/ticket-reservation", ticketReservationRouter);
 
 export default router;

--- a/src/api/ticket-reservation.ts
+++ b/src/api/ticket-reservation.ts
@@ -136,7 +136,9 @@ router.post(
         });
 
         if (!inventory) {
-          throw new Error("Inventory not found for selected date");
+          return res
+            .status(404)
+            .json({ error: "Inventory not found for selected date" });
         }
 
         if (
@@ -238,36 +240,40 @@ router.patch(
   })
 );
 
-router.get("/", authToken, asyncHandler(async (req: AuthRequest, res) => {
-  const userId = req.user?.userId;
+router.get(
+  "/",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const userId = req.user?.userId;
 
-  try {
-    const reservations = await prisma.ticketReservation.findMany({
-      where: {
-        userId: userId ? Number(userId) : undefined,
-        OR: [
-          { status: { not: "CANCELLED" } },
-          {
-            AND: [
-              { status: "CANCELLED" },
-              { cancelReason: { not: "AUTO_EXPIRED" } },
-            ],
-          },
-        ],
-      },
-      include: {
-        ticketType: true,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
+    try {
+      const reservations = await prisma.ticketReservation.findMany({
+        where: {
+          userId: userId ? Number(userId) : undefined,
+          OR: [
+            { status: { not: "CANCELLED" } },
+            {
+              AND: [
+                { status: "CANCELLED" },
+                { cancelReason: { not: "AUTO_EXPIRED" } },
+              ],
+            },
+          ],
+        },
+        include: {
+          ticketType: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
 
-    res.status(200).json(reservations);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: "Internal server error" });
-  }
-}));
+      res.status(200).json(reservations);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  })
+);
 
 export default router;

--- a/src/api/ticket-reservation.ts
+++ b/src/api/ticket-reservation.ts
@@ -168,7 +168,7 @@ router.post(
         return updatedReservation;
       });
 
-      return res.status(200).json({ reservation: confirmed });
+      return res.status(200).json(confirmed);
     } catch (err) {
       console.error(err);
       return res.status(500).json({ error: "Internal server error" });

--- a/src/api/ticket-reservation.ts
+++ b/src/api/ticket-reservation.ts
@@ -1,0 +1,273 @@
+import { PrismaClient, CancelReason } from "@prisma/client";
+import express from "express";
+import { AuthRequest, authToken } from "../middlewares/authMiddleware";
+import { asyncHandler } from "../utils/asyncHandler";
+import { startOfDay, addDays } from "date-fns";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.post(
+  "/",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const {
+      ticketTypeId,
+      date,
+      adults,
+      children,
+      firstName,
+      lastName,
+      email,
+      phoneNumber,
+      nationality,
+      specialRequests,
+    } = req.body;
+
+    const userId = req.user?.userId;
+
+    if (
+      !ticketTypeId ||
+      !date ||
+      adults === undefined ||
+      children === undefined ||
+      !firstName ||
+      !lastName ||
+      !phoneNumber ||
+      !userId
+    ) {
+      return res.status(400).json({ error: "All fields are required" });
+    }
+
+    try {
+      const reservation = await prisma.$transaction(async (tx) => {
+        const inventory = await tx.ticketInventory.findFirst({
+          where: {
+            ticketTypeId: Number(ticketTypeId),
+            date: startOfDay(new Date(date)),
+          },
+        });
+
+        if (!inventory) {
+          throw new Error("Inventory not found for selected date");
+        }
+
+        if (
+          inventory.availableAdultTickets < Number(adults) ||
+          inventory.availableChildTickets < Number(children)
+        ) {
+          throw new Error("Not enough tickets available for the selected date");
+        }
+
+        const ticketType = await tx.ticketType.findUnique({
+          where: { id: Number(ticketTypeId) },
+          select: {
+            adultPrice: true,
+            childPrice: true,
+          },
+        });
+
+        if (!ticketType) {
+          throw new Error("Ticket type not found");
+        }
+
+        const totalPrice =
+          Number(adults) * ticketType.adultPrice +
+          Number(children) * ticketType.childPrice;
+
+        const createdReservation = await tx.ticketReservation.create({
+          data: {
+            ticketTypeId: Number(ticketTypeId),
+            userId: userId!,
+            date: startOfDay(new Date(date)),
+            adults: Number(adults),
+            children: Number(children),
+            firstName,
+            lastName,
+            email,
+            phoneNumber,
+            nationality,
+            specialRequests: JSON.stringify(specialRequests || []),
+            status: "PENDING",
+            totalPrice,
+          },
+        });
+
+        return createdReservation;
+      });
+
+      return res.status(201).json(reservation);
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: "Internal server error" });
+    }
+  })
+);
+
+router.post(
+  "/confirm",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { reservationId } = req.body;
+
+    if (!reservationId) {
+      return res.status(400).json({ error: "Reservation ID is required" });
+    }
+
+    try {
+      const confirmed = await prisma.$transaction(async (tx) => {
+        const reservation = await tx.ticketReservation.findUnique({
+          where: { id: reservationId },
+        });
+
+        if (!reservation) {
+          throw new Error("Reservation not found");
+        }
+
+        if (reservation.status !== "PENDING") {
+          throw new Error("Reservation cannot be confirmed");
+        }
+
+        const inventory = await tx.ticketInventory.findFirst({
+          where: {
+            ticketTypeId: reservation.ticketTypeId,
+            date: startOfDay(new Date(reservation.date)),
+          },
+        });
+
+        if (!inventory) {
+          throw new Error("Inventory not found for selected date");
+        }
+
+        if (
+          inventory.availableAdultTickets < reservation.adults ||
+          inventory.availableChildTickets < reservation.children
+        ) {
+          throw new Error("Not enough tickets available for the selected date");
+        }
+
+        await tx.ticketInventory.update({
+          where: { id: inventory.id },
+          data: {
+            availableAdultTickets: {
+              decrement: reservation.adults,
+            },
+            availableChildTickets: {
+              decrement: reservation.children,
+            },
+          },
+        });
+
+        const updatedReservation = await tx.ticketReservation.update({
+          where: { id: reservationId },
+          data: { status: "CONFIRMED" },
+        });
+
+        return updatedReservation;
+      });
+
+      return res.status(200).json({ reservation: confirmed });
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: "Internal server error" });
+    }
+  })
+);
+
+router.patch(
+  "/:id/cancel",
+  authToken,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const reservationId = Number(req.params.id);
+    const { cancelReason } = req.body;
+
+    if (!reservationId) {
+      return res.status(400).json({ error: "Reservation ID is required" });
+    }
+
+    if (!cancelReason || !Object.values(CancelReason).includes(cancelReason)) {
+      return res.status(400).json({ error: "Valid cancel reason is required" });
+    }
+
+    try {
+      const cancelled = await prisma.$transaction(async (tx) => {
+        const reservation = await tx.ticketReservation.findUnique({
+          where: { id: reservationId },
+        });
+
+        if (!reservation) {
+          throw new Error("Reservation not found");
+        }
+
+        const previousStatus = reservation.status;
+
+        const updated = await tx.ticketReservation.update({
+          where: { id: reservationId },
+          data: { status: "CANCELLED", cancelReason: cancelReason },
+        });
+
+        if (
+          previousStatus === "CONFIRMED" &&
+          updated.status === "CANCELLED" &&
+          (cancelReason === "USER_REQUESTED" || cancelReason === "ADMIN_FORCED")
+        ) {
+          await tx.ticketInventory.updateMany({
+            where: {
+              ticketTypeId: reservation.ticketTypeId,
+              date: startOfDay(new Date(reservation.date)),
+            },
+            data: {
+              availableAdultTickets: {
+                increment: reservation.adults,
+              },
+              availableChildTickets: {
+                increment: reservation.children,
+              },
+            },
+          });
+        }
+
+        return updated;
+      });
+
+      return res.status(200).json({ reservation: cancelled });
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: "Internal server error" });
+    }
+  })
+);
+
+router.get("/", authToken, asyncHandler(async (req: AuthRequest, res) => {
+  const userId = req.user?.userId;
+
+  try {
+    const reservations = await prisma.ticketReservation.findMany({
+      where: {
+        userId: userId ? Number(userId) : undefined,
+        OR: [
+          { status: { not: "CANCELLED" } },
+          {
+            AND: [
+              { status: "CANCELLED" },
+              { cancelReason: { not: "AUTO_EXPIRED" } },
+            ],
+          },
+        ],
+      },
+      include: {
+        ticketType: true,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    res.status(200).json(reservations);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Internal server error" });
+  }
+}));
+
+export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Added **POST /api/v1/ticket-reservation** endpoint for creating ticket reservations.
- Implemented **POST /api/v1/ticket-reservation/confirm** endpoint to confirm ticket reservations.
- Simplified `res.data` structure in confirm response to return only the confirmed reservation.
- Applied `startOfDay()` consistently to all date storage and comparison to prevent date mismatch errors.
- Minor backend refactors for consistency and clarity in transaction handling.


## Why
- This enables users to reserve tickets with specific dates, guest counts, and contact info.
- Confirmation endpoint ensures inventory stock is decremented only upon payment success.
- Simplifying the response makes the frontend integration cleaner and reduces parsing complexity.
- Using `startOfDay()` prevents subtle bugs where times would mismatch despite being the same calendar date.


## Testing
- Ran server locally and tested the following flows:
  - POST `/api/v1/ticket-reservation` with valid body → returned pending reservation.
  - POST `/api/v1/ticket-reservation/confirm` with valid reservation ID → decremented inventory correctly and returned confirmed reservation.
  - Tested invalid inputs → verified proper 400/500 error handling.
- Verified with Postman and local frontend integration.

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #53 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
