### PR TITLE
Feat/admin

### DIFF
--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -830,11 +830,27 @@ router.get(
     try {
       const roomInventories = await prisma.roomInventory.findMany({
         where: { lodgeId },
+        include: {
+          roomType: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
         orderBy: { date: "asc" },
       });
 
       const ticketInventories = await prisma.ticketInventory.findMany({
         where: { lodgeId },
+        include: {
+          ticketType: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
         orderBy: { date: "asc" },
       });
 

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -284,33 +284,4 @@ router.delete(
   })
 );
 
-router.get(
-  "/:id/inventories",
-  asyncHandler(async (req, res) => {
-    const { id } = req.params;
-    const lodgeId = Number(id);
-
-    if (isNaN(lodgeId)) {
-      return res.status(400).json({ message: "Invalid lodge ID" });
-    }
-
-    try {
-      const roomInventories = await prisma.roomInventory.findMany({
-        where: { lodgeId },
-        orderBy: { date: "asc" },
-      });
-
-      const ticketInventories = await prisma.ticketInventory.findMany({
-        where: { lodgeId },
-        orderBy: { date: "asc" },
-      });
-
-      res.json({ roomInventories, ticketInventories });
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ message: "Failed to fetch inventories" });
-    }
-  })
-);
-
 export default router;

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -284,4 +284,33 @@ router.delete(
   })
 );
 
+router.get(
+  "/:id/inventories",
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    const lodgeId = Number(id);
+
+    if (isNaN(lodgeId)) {
+      return res.status(400).json({ message: "Invalid lodge ID" });
+    }
+
+    try {
+      const roomInventories = await prisma.roomInventory.findMany({
+        where: { lodgeId },
+        orderBy: { date: "asc" },
+      });
+
+      const ticketInventories = await prisma.ticketInventory.findMany({
+        where: { lodgeId },
+        orderBy: { date: "asc" },
+      });
+
+      res.json({ roomInventories, ticketInventories });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Failed to fetch inventories" });
+    }
+  })
+);
+
 export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Added new API route in `admin/lodge.ts` backend to fetch inventories by lodgeId
- Implements `GET /v1/admin/lodge/:id/inventories`
- Returns all RoomInventory and TicketInventory for the given lodgeId with their related RoomType and TicketType details (name, id)


## Why
- Admins need to view and manage room and ticket inventories per lodge
- Enables frontend calendar view to show date-by-date stock levels for rooms and tickets


## Testing
- Ran server locally and confirmed route works:
  - `GET /v1/admin/lodge/:id/inventories` returns JSON with roomInventories and ticketInventories
  - Verified inventories include related RoomType and TicketType info
- Checked with Postman using a valid lodgeId
- Confirmed dates, availableRooms, availableAdultTickets, and availableChildTickets load correctly


## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
