### PR TITLE
Feat/admin

### DIFF
--- a/prisma/migrations/20250720085445_delete_nullable/migration.sql
+++ b/prisma/migrations/20250720085445_delete_nullable/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Made the column `ticketReservationId` on table `TicketReview` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "TicketReview" DROP CONSTRAINT "TicketReview_ticketReservationId_fkey";
+
+-- AlterTable
+ALTER TABLE "TicketReview" ALTER COLUMN "ticketReservationId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "TicketReview" ADD CONSTRAINT "TicketReview_ticketReservationId_fkey" FOREIGN KEY ("ticketReservationId") REFERENCES "TicketReservation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,7 +301,7 @@ model TicketReservation {
 model TicketReview {
   id                  Int      @id @default(autoincrement())
   ticketTypeId        Int
-  ticketReservationId Int?
+  ticketReservationId Int
   userId              Int
   rating              Int
   comment             String?
@@ -312,7 +312,7 @@ model TicketReview {
   user       User       @relation(fields: [userId], references: [id])
 
   reports     TicketReportReview[]
-  reservation TicketReservation?   @relation(fields: [ticketReservationId], references: [id])
+  reservation TicketReservation    @relation(fields: [ticketReservationId], references: [id])
 }
 
 model TicketBookmark {

--- a/src/api/ticket-review.ts
+++ b/src/api/ticket-review.ts
@@ -24,6 +24,15 @@ router.get(
                 nickname: true,
               },
             },
+            reservation: {
+              include: {
+                ticketType: {
+                  include: {
+                    lodge: true,
+                  },
+                },
+              },
+            },
           },
           orderBy: {
             createdAt: "desc",

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -167,12 +167,32 @@ router.post(
           .json({ message: "You have already reviewed this ticket" });
       }
 
+      const reservation = await prisma.ticketReservation.findFirst({
+        where: {
+          userId: userId!,
+          ticketTypeId: ticket.id,
+          status: "CONFIRMED",
+          date: {
+            lt: new Date(),
+          },
+        },
+      });
+
+      if (!reservation) {
+        return res
+          .status(403)
+          .json({
+            message: "You can only review used & confirmed reservations",
+          });
+      }
+
       const newReview = await prisma.ticketReview.create({
         data: {
           ticketTypeId: ticket.id,
           userId: userId!,
           rating,
           comment,
+          ticketReservationId: reservation.id,
         },
         include: {
           ticketType: true,

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -179,11 +179,9 @@ router.post(
       });
 
       if (!reservation) {
-        return res
-          .status(403)
-          .json({
-            message: "You can only review used & confirmed reservations",
-          });
+        return res.status(403).json({
+          message: "You can only review used & confirmed reservations",
+        });
       }
 
       const newReview = await prisma.ticketReview.create({
@@ -220,6 +218,13 @@ router.get(
         include: {
           user: {
             select: { nickname: true },
+          },
+          reservation: {
+            select: {
+              date: true,
+              adults: true,
+              children: true,
+            },
           },
         },
         orderBy: {


### PR DESCRIPTION
# Pull Request

## Description
- Added reservation field to the response of ticket review APIs in both ticket.ts and ticket-review.ts
- Updated Prisma schema: changed ticketReservationId in TicketReview model from nullable to required (Int? → Int)
- Updated related Prisma create and findMany logic to include reservation when fetching reviews
- Ensured that reservation details (date, adults, children) are sent to the frontend

## Why
- Displaying reservation metadata (e.g., date, number of guests) in the frontend ReviewCard requires the review API to return reservation information
- Making ticketReservationId required ensures that every review is linked to a valid, used ticket reservation, which improves data consistency and enforces business rules

## Testing
- Ran npx prisma migrate dev --name require-reservation-in-ticketReview
- Tested POST /ticket/:id/review to ensure review cannot be created without a valid past reservation
- Confirmed GET /ticket/:id/reviews and GET /ticket-review/my return reviews with populated reservation
- Verified on frontend that review.reservation now renders properly in ReviewCard component

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
fixes #70 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
