### PR TITLE
Feat/list

### DIFF
--- a/src/api/lodge.ts
+++ b/src/api/lodge.ts
@@ -179,12 +179,29 @@ router.get(
             })
           );
 
+          const visibleReviews = await prisma.hotSpringLodgeReview.findMany({
+            where: {
+              lodgeId: lodge.id,
+              isHidden: false,
+            },
+            select: { rating: true },
+          });
+
+          const reviewCount = visibleReviews.length;
+          const averageRating =
+            reviewCount > 0
+              ? visibleReviews.reduce((sum, r) => sum + r.rating, 0) /
+                reviewCount
+              : 0;
+
           return {
             ...lodge,
             roomTypes: roomTypesWithPrice,
             region,
             adults: adultsNum,
             children: childrenNum,
+            averageRating: parseFloat(averageRating.toFixed(1)),
+            reviewCount,
           };
         })
       );

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -54,7 +54,11 @@ router.get(
       include: {
         ticketType: {
           include: {
-            lodge: true,
+            lodge: {
+              include: {
+                images: true,
+              },
+            },
           },
         },
       },
@@ -76,6 +80,7 @@ router.get(
           availableAdultTickets: 0,
           availableChildTickets: 0,
           date: searchDate,
+          lodgeImage: tt.lodge.images?.[0]?.imageUrl || null,
         });
       }
       const agg = ticketMap.get(tt.id);

--- a/src/api/ticket.ts
+++ b/src/api/ticket.ts
@@ -85,6 +85,27 @@ router.get(
 
     const tickets = Array.from(ticketMap.values());
 
+    for (const ticket of tickets) {
+      const reviews = await prisma.ticketReview.findMany({
+        where: {
+          ticketTypeId: ticket.id,
+          isHidden: false,
+        },
+        select: {
+          rating: true,
+        },
+      });
+
+      const reviewCount = reviews.length;
+      const averageRating =
+        reviewCount > 0
+          ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviewCount
+          : 0;
+
+      ticket.reviewCount = reviewCount;
+      ticket.averageRating = parseFloat(averageRating.toFixed(1));
+    }
+
     if (sort) {
       switch (sort) {
         case "adult_price_asc":


### PR DESCRIPTION
# Pull Request

## Description
- Added average rating (averageRating) and total review count (reviewCount) for each ticket in /ticket/search response
- Calculated ratings using non-hidden reviews (isHidden: false) from ticketReview model
- Included first image from each associated lodge (HotSpringLodgeImage) as lodgeImage in the ticket response
- Updated Prisma query in ticket/search to include lodge.images for image extraction

## Why
- Enhances frontend ticket list page with additional user-facing context (ratings and reviews)
- Provides visual content (thumbnail) for each ticket card by exposing lodge’s first image
- Improves overall user experience by showing richer ticket information without additional API calls

## Testing
- Ran the backend server locally
- Called /ticket/search endpoint with test query params
- Confirmed response objects contain valid averageRating, reviewCount, and lodgeImage fields
- Verified logic when tickets have no reviews or no images (fallbacks handled correctly)

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #20

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
