### PR TITLE
Fix/reset pwd

### DIFF
--- a/src/api/reset-password.ts
+++ b/src/api/reset-password.ts
@@ -71,7 +71,7 @@ router.post(
           .json({ message: "Too many attempts. Please request a new code." });
       }
 
-      if (latestCodeEntry.code !== code) {
+      if (String(latestCodeEntry.code) !== String(code)) {
         const updated = await prisma.passwordResetCode.update({
           where: { id: latestCodeEntry.id },
           data: {
@@ -85,7 +85,7 @@ router.post(
         });
       }
 
-      await prisma.passwordResetCode.delete({
+      await prisma.passwordResetCode.deleteMany({
         where: { id: latestCodeEntry.id },
       });
 


### PR DESCRIPTION
# Pull Request

This pull request improves error handling and response consistency in the `reset-password` API endpoint. The most significant changes include adding detailed error logging, enhancing client responses with additional information, and restructuring some logic for better readability and maintainability.

### Error handling improvements:

* Added `try-catch` blocks to handle potential errors when fetching the reset code, updating attempts, and deleting used reset codes. Each block logs specific error messages and returns appropriate HTTP status codes. (`src/api/reset-password.ts`: [[1]](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eR49-R51) [[2]](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eR62-R118)

### Enhanced client responses:

* Updated error responses to include a `remainingAttempts` field, providing users with more context about their status when a reset code is invalid or too many attempts have been made. (`src/api/reset-password.ts`: [src/api/reset-password.tsR62-R118](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eR62-R118))

### Code quality improvements:

* Refactored the `latestCodeEntry` variable to be declared outside the `try` block, improving readability and scope management. (`src/api/reset-password.ts`: [src/api/reset-password.tsR49-R51](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eR49-R51))
* Used `deleteMany` instead of `delete` for clearing reset codes, ensuring consistency in handling potential edge cases. (`src/api/reset-password.ts`: [src/api/reset-password.tsR62-R118](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eR62-R118))

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #78 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
