### PR TITLE
Fix/reset pwd

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -166,7 +166,12 @@ router.post(
       });
       const verifyUrl = `${process.env.FRONTEND_URL}/${locale}/signup/email-verified?token=${token}`;
 
-      await sendEmail({ email, type: "verify-email", content: verifyUrl });
+      await sendEmail({
+        email,
+        type: "verify-email",
+        content: verifyUrl,
+        locale,
+      });
 
       await prisma.emailVerification.upsert({
         where: { email },

--- a/src/api/reset-password.ts
+++ b/src/api/reset-password.ts
@@ -11,7 +11,7 @@ const prisma = new PrismaClient();
 router.post(
   "/",
   asyncHandler(async (req, res) => {
-    const { email } = req.body;
+    const { email, locale } = req.body;
 
     try {
       const user = await prisma.user.findUnique({
@@ -32,7 +32,7 @@ router.post(
         },
       });
 
-      await sendEmail({ email, type: "reset-password", content: code });
+      await sendEmail({ email, type: "reset-password", content: code, locale });
       return res.status(200).json({ message: "Reset code sent to your email" });
     } catch (err) {
       console.error(err);

--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -12,11 +12,51 @@ interface SendEmailOptions {
   email: string;
   type: "reset-password" | "verify-email";
   content: string;
+  locale: string;
 }
 
-export const sendEmail = async ({ email, type, content }: SendEmailOptions) => {
-  let subject = "";
-  let html = "";
+const EMAIL_TEXT = {
+  "reset-password": {
+    en: {
+      subject: "Password Reset Request",
+      title: "🔒 Password Reset Code",
+      desc: "You requested a password reset.<br />Please enter the code below within <b>10 minutes</b>.",
+      ignore: "If you didn’t request this, you can safely ignore this email.",
+    },
+    ko: {
+      subject: "비밀번호 재설정 요청",
+      title: "🔒 비밀번호 재설정 코드",
+      desc: "비밀번호 재설정을 요청하셨습니다.<br /><b>10분 이내</b>에 아래 코드를 입력해 주세요.",
+      ignore:
+        "비밀번호 재설정을 요청하지 않았다면 이 메일은 무시하셔도 됩니다.",
+    },
+  },
+  "verify-email": {
+    en: {
+      subject: "Email Verification",
+      title: "📧 Verify Your Email",
+      desc: "Thanks for signing up! Please confirm your email address by clicking below.",
+      btn: "Verify Email",
+      ignore: "If you didn’t sign up, you can safely ignore this email.",
+    },
+    ko: {
+      subject: "이메일 인증",
+      title: "📧 이메일을 인증해 주세요",
+      desc: "회원가입을 환영합니다! 아래 버튼을 눌러 이메일 인증을 완료해 주세요.",
+      btn: "이메일 인증하기",
+      ignore: "회원가입을 하지 않으셨다면 이 메일을 무시하셔도 됩니다.",
+    },
+  },
+};
+
+export const sendEmail = async ({
+  email,
+  type,
+  content,
+  locale,
+}: SendEmailOptions) => {
+  const lang = ["ko", "en"].includes(locale) ? locale : "en";
+  const t = (EMAIL_TEXT[type] as Record<string, any>)[lang];
 
   const outerStyle = [
     "max-width:480px",
@@ -87,47 +127,47 @@ export const sendEmail = async ({ email, type, content }: SendEmailOptions) => {
 
   const logoImg = `<img src="https://res.cloudinary.com/dqghdryuh/image/upload/v1753522157/koripLogo_go0ssz.png" style="${logoStyle}" alt="Korips Logo" />`;
 
+  let subject = t.subject;
+  let html = "";
+
   if (type === "reset-password") {
-    subject = "Password Reset Request";
     html = `
       <div style="${outerStyle}">
         ${logoImg}
-        <div style="${titleStyle}">🔒 Password Reset Code</div>
+        <div style="${titleStyle}">${t.title}</div>
         <p style="font-size:17px;color:#222;margin-bottom:23px;text-align:center;">
-          You requested a password reset.<br />
-          Please enter the code below within <b>10 minutes</b>.
+          ${t.desc}
         </p>
         <div style="${codeBoxStyle}">
           <span style="${codeStyle}">${content}</span>
         </div>
         <p style="font-size:13px;color:#888;text-align:center;margin-bottom:0;">
-          If you didn’t request this, you can safely ignore this email.
+          ${t.ignore}
         </p>
         <hr style="${hrStyle}">
         <div style="${footerStyle}">&copy; ${new Date().getFullYear()} Korips. All rights reserved.</div>
       </div>
     `;
   } else if (type === "verify-email") {
-    subject = "Email Verification";
     html = `
-  <div style="${outerStyle}">
-    ${logoImg}
-    <div style="${titleStyle}">📧 Verify Your Email</div>
-    <p style="font-size:17px;color:#222;margin-bottom:28px;text-align:center;">
-      Thanks for signing up! Please confirm your email address by clicking below.
-    </p>
-    <div style="text-align:center;margin:28px 0;">
-      <a href="${content}" style="${btnStyle}" target="_blank" rel="noopener">
-        Verify Email
-      </a>
-    </div>
-    <p style="font-size:13px;color:#888;text-align:center;margin:20px 0 0 0;">
-      If you didn’t sign up, you can safely ignore this email.
-    </p>
-    <hr style="${hrStyle}">
-    <div style="${footerStyle}">&copy; ${new Date().getFullYear()} Korips. All rights reserved.</div>
-  </div>
-`;
+      <div style="${outerStyle}">
+        ${logoImg}
+        <div style="${titleStyle}">${t.title}</div>
+        <p style="font-size:17px;color:#222;margin-bottom:28px;text-align:center;">
+          ${t.desc}
+        </p>
+        <div style="text-align:center;margin:28px 0;">
+          <a href="${content}" style="${btnStyle}" target="_blank" rel="noopener">
+            ${t.btn}
+          </a>
+        </div>
+        <p style="font-size:13px;color:#888;text-align:center;margin:20px 0 0 0;">
+          ${t.ignore}
+        </p>
+        <hr style="${hrStyle}">
+        <div style="${footerStyle}">&copy; ${new Date().getFullYear()} Korips. All rights reserved.</div>
+      </div>
+    `;
   }
 
   return mailer.sendMail({


### PR DESCRIPTION
# Pull Request

This pull request introduces localization support for email notifications, allowing dynamic content in multiple languages (English and Korean) based on the user's locale. The changes include updates to the `sendEmail` function, modifications to API routes handling email and password reset, and the addition of a new localization structure.

### Localization Support for Emails:

* **Dynamic Localization in `sendEmail`:** The `sendEmail` function now supports a `locale` parameter, which determines the language of email content. A new `EMAIL_TEXT` object was introduced to store localized email templates for both "reset-password" and "verify-email" types in English (`en`) and Korean (`ko`). [[1]](diffhunk://#diff-f77c8383243c2f59482f0f719c6e3a7e5f2a8d4bf90628a493cf84ecbf144861R15-R59) [[2]](diffhunk://#diff-f77c8383243c2f59482f0f719c6e3a7e5f2a8d4bf90628a493cf84ecbf144861R130-R165)

### API Updates for Locale Handling:

* **`auth.ts` Updates:** Added `locale` as a parameter when calling the `sendEmail` function in the email verification process.

* **`reset-password.ts` Updates:** The password reset API now accepts `locale` from the request body and passes it to the `sendEmail` function to send localized reset password emails. [[1]](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eL14-R14) [[2]](diffhunk://#diff-8ed9d228931f0acf0db9d3b1456abbe4bf440c35d224751fc599e1dcda40730eL35-R35)

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
Fixes #80 

## Checklist
- [x] Code builds and runs locally
- [x] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
