### PR TITLE
Feat/translation

### DIFF
--- a/prisma/migrations/20250807182108_add_translating_columns_in_ticket_type_table/migration.sql
+++ b/prisma/migrations/20250807182108_add_translating_columns_in_ticket_type_table/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "TicketType" ADD COLUMN     "descriptionEn" TEXT,
+ADD COLUMN     "nameEn" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -255,7 +255,9 @@ model TicketType {
   id                Int      @id @default(autoincrement())
   lodgeId           Int
   name              String
+  nameEn            String?
   description       String?
+  descriptionEn     String?
   adultPrice        Int
   childPrice        Int
   totalAdultTickets Int

--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -57,8 +57,6 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
     roomTypeImages = req.files["roomTypeImages"] || [];
   }
 
-  console.log("Received roomTypeImages:", roomTypeImages.length); // 디버깅용
-
   if (
     !name ||
     !address ||

--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -90,18 +90,12 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
 
   let uploadRoomTypeImages: UploadedRoomTypeImage[] = [];
   if (roomTypeImages.length > 0) {
-    console.log(
-      "Processing roomTypeImages:",
-      roomTypeImages.map((f) => f.originalname)
-    ); // 디버깅용
 
     for (let roomIdx = 0; roomIdx < roomTypes.length; roomIdx++) {
       const roomFiles = roomTypeImages.filter((file: Express.Multer.File) => {
         const match = file.originalname.match(/roomType_(\d+)_/);
         return match && Number(match[1]) === roomIdx;
       });
-
-      console.log(`Room ${roomIdx} files:`, roomFiles.length); // 디버깅용
 
       if (roomFiles.length > 0) {
         const uploaded = await Promise.all(
@@ -117,8 +111,6 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
       }
     }
   }
-
-  console.log("Final uploadRoomTypeImages:", uploadRoomTypeImages.length); // 디버깅용
 
   try {
     const result = await prisma.$transaction(
@@ -193,8 +185,6 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
                 (img) => img.idx === index
               );
 
-              console.log(`Creating images for room ${index}:`, images.length); // 디버깅용
-
               if (images.length > 0) {
                 const createdImages = await tx.roomTypeImage.createMany({
                   data: images.map((img) => ({
@@ -243,11 +233,18 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
 
         const createdTicketTypes = await Promise.all(
           ticketTypes.map(async (ticket: TicketInput) => {
+            const nameEn = await translateText(ticket.name, "EN");
+            const descriptionEn = ticket.description
+              ? await translateText(ticket.description, "EN")
+              : null;
+              
             const newTicketType = await tx.ticketType.create({
               data: {
                 lodgeId: lodge.id,
                 name: ticket.name,
+                nameEn,
                 description: ticket.description,
+                descriptionEn,
                 adultPrice: ticket.adultPrice,
                 childPrice: ticket.childPrice,
                 totalAdultTickets: ticket.totalAdultTickets,

--- a/src/api/admin/lodge.ts
+++ b/src/api/admin/lodge.ts
@@ -237,7 +237,7 @@ router.post("/", uploadMiddleware, (async (req: Request, res: Response) => {
             const descriptionEn = ticket.description
               ? await translateText(ticket.description, "EN")
               : null;
-              
+
             const newTicketType = await tx.ticketType.create({
               data: {
                 lodgeId: lodge.id,
@@ -609,7 +609,9 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
                 data: {
                   lodgeId: updated.id,
                   name: roomType.name,
+                  nameEn,
                   description: roomType.description,
+                  descriptionEn,
                   basePrice: roomType.basePrice,
                   weekendPrice: roomType.weekendPrice,
                   maxAdults: roomType.maxAdults,
@@ -725,12 +727,19 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
         }
 
         for (const ticket of ticketTypes) {
+          const nameEn = await translateText(ticket.name, "EN");
+          const descriptionEn = ticket.description
+            ? await translateText(ticket.description, "EN")
+            : null;
+
           if (ticket.id) {
             await tx.ticketType.update({
               where: { id: ticket.id },
               data: {
                 name: ticket.name,
+                nameEn,
                 description: ticket.description,
+                descriptionEn,
                 adultPrice: ticket.adultPrice,
                 childPrice: ticket.childPrice,
                 totalAdultTickets: ticket.totalAdultTickets,
@@ -788,7 +797,9 @@ router.patch("/:id", uploadMiddleware, (async (req, res) => {
               data: {
                 lodgeId: Number(id),
                 name: ticket.name,
+                nameEn,
                 description: ticket.description,
+                descriptionEn,
                 adultPrice: ticket.adultPrice,
                 childPrice: ticket.childPrice,
                 totalAdultTickets: ticket.totalAdultTickets,


### PR DESCRIPTION
# Pull Request

This pull request adds support for English translations of ticket type names and descriptions, and cleans up debugging logs in the lodge admin API. The main changes are the addition of new columns to the database and schema, updating the logic to generate and store English translations, and removing unnecessary console logs.

**Internationalization support for ticket types:**

* Added `nameEn` and `descriptionEn` columns to the `TicketType` table in the database to store English translations.
* Updated the Prisma schema (`schema.prisma`) to include the new optional fields `nameEn` and `descriptionEn` in the `TicketType` model.
* Modified the lodge creation (`POST /`) and update (`PATCH /:id`) endpoints to automatically translate ticket type `name` and `description` to English using `translateText`, and save the results in the new fields. [[1]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3R236-R247) [[2]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3R730-R742) [[3]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3R800-R802)

**Code cleanup:**

* Removed multiple debugging `console.log` statements from the lodge admin API to clean up server logs. [[1]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3L60-L61) [[2]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3L95-L107) [[3]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3L123-L124) [[4]](diffhunk://#diff-a30862ffe541aa2d068efc5501a42dd46e582944016b6192da1095a0d272b0f3L198-L199)

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [ ] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
