### PR TITLE
Fix/auth

### DIFF
--- a/src/api/admin/user.ts
+++ b/src/api/admin/user.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import express from "express";
 import { AuthRequest } from "../../middlewares/authMiddleware";
 import { asyncHandler } from "../../utils/asyncHandler";
@@ -15,22 +15,22 @@ router.get(
 
     try {
       const [users, total] = await prisma.$transaction([
-      prisma.user.findMany({
-        select: {
-          id: true,
-          email: true,
-          nickname: true,
-          role: true,
-          createdAt: true,
-        },
-        orderBy: {
-          createdAt: "desc",
-        },
-        skip,
-        take: limit,
-      }),
-      prisma.user.count(),
-    ]);
+        prisma.user.findMany({
+          select: {
+            id: true,
+            email: true,
+            nickname: true,
+            role: true,
+            createdAt: true,
+          },
+          orderBy: {
+            createdAt: "desc",
+          },
+          skip,
+          take: limit,
+        }),
+        prisma.user.count(),
+      ]);
       res.status(200).json({ data: users, total, page, limit });
     } catch (err) {
       return res.status(500).json({ message: "Internal server error" });
@@ -48,24 +48,47 @@ router.delete(
       return res.status(400).json({ message: "Invalid user ID" });
     }
 
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true, nickname: true },
+    });
+    if (!user) return res.status(404).json({ message: "User not found" });
+
     try {
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { id: true, nickname: true, email: true },
-      });
+      await prisma.$transaction(async (tx) => {
+        await tx.ticketReportReview.deleteMany({ where: { userId } });
+        await tx.reportReview.deleteMany({ where: { userId } });
 
-      if (!user) {
-        return res.status(404).json({ message: "User not found" });
-      }
+        await tx.ticketBookmark.deleteMany({ where: { userId } });
+        await tx.hotSpringLodgeBookmark.deleteMany({ where: { userId } });
 
-      await prisma.user.delete({
-        where: { id: userId },
+        await tx.ticketReview.deleteMany({ where: { userId } });
+        await tx.hotSpringLodgeReview.deleteMany({ where: { userId } });
+
+        await tx.emailVerification.deleteMany({ where: { userId } });
+
+        await tx.ticketReservation.deleteMany({ where: { userId } });
+
+        await tx.reservation.deleteMany({ where: { userId } });
+
+        await tx.user.delete({ where: { id: userId } });
       });
 
       return res
         .status(200)
         .json({ message: "User deleted successfully", user });
-    } catch (err) {
+    } catch (err: any) {
+      console.error("DELETE /v1/admin/user/:id error:", err);
+
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2003"
+      ) {
+        return res
+          .status(409)
+          .json({ message: "Cannot delete user due to related records." });
+      }
+
       return res.status(500).json({ message: "Internal server error" });
     }
   })
@@ -151,7 +174,7 @@ router.get(
     const limit = parseInt(req.query.limit as string) || 10;
     const skip = (page - 1) * limit;
 
-    const [reviews,total] = await Promise.all([
+    const [reviews, total] = await Promise.all([
       prisma.hotSpringLodgeReview.findMany({
         where: { userId },
         include: {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -10,7 +10,6 @@ import {
   verifyRefreshToken,
 } from "../utils/jwt";
 import { asyncHandler } from "../utils/asyncHandler";
-import { differenceInSeconds } from "date-fns";
 
 const router = express.Router();
 const prisma = new PrismaClient();


### PR DESCRIPTION
# Pull Request

## Description
- Refactored DELETE /v1/admin/user/:id route in the admin backend to properly handle foreign key constraints.
- Implemented a Prisma transaction to delete all related child records (reviews, bookmarks, reservations, tickets, reports, email verifications) before deleting the user.
- Added clear deletion order based on schema relationships to prevent P2003 FK constraint errors.
- Improved error logging in the catch block to print Prisma error details for easier debugging.

## Why
- Previously, deleting a user in the admin panel caused a 500 Internal Server Error due to existing foreign key references in related tables.
- This refactor ensures all dependent records are removed in the correct order before deleting the user, eliminating FK violations.
- Makes the admin delete function reliable and prevents accidental database constraint errors.

## Testing
None

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [ ] All tests pass
- [ ] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
