### PR TITLE
Feat/support

### DIFF
--- a/prisma/migrations/20250818083654_add_support_translation_fields/migration.sql
+++ b/prisma/migrations/20250818083654_add_support_translation_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Support" ADD COLUMN     "originalLang" TEXT,
+ADD COLUMN     "questionKo" TEXT;

--- a/prisma/migrations/20250818084452_support_add_answer_en/migration.sql
+++ b/prisma/migrations/20250818084452_support_add_answer_en/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Support" ADD COLUMN     "answerEn" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -376,15 +376,17 @@ model Event {
 }
 
 model Support {
-  id         Int          @id @default(autoincrement())
-  userId     Int
-  name       String
-  question   String
-  answer     String?
-  status     SupportStatus @default(PENDING)
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
-  answeredAt DateTime?
+  id           Int           @id @default(autoincrement())
+  userId       Int
+  name         String
+  question     String
+  questionKo   String?
+  originalLang String?
+  answer       String?
+  status       SupportStatus @default(PENDING)
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  answeredAt   DateTime?
 
   user User @relation(fields: [userId], references: [id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -383,6 +383,7 @@ model Support {
   questionKo   String?
   originalLang String?
   answer       String?
+  answerEn     String?
   status       SupportStatus @default(PENDING)
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt

--- a/src/api/admin/support.ts
+++ b/src/api/admin/support.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { PrismaClient, SupportStatus } from "@prisma/client";
 import { asyncHandler } from "../../utils/asyncHandler";
+import { translateText } from "../../utils/deepl";
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -21,7 +22,10 @@ router.get(
           userId: true,
           name: true,
           question: true,
+          questionKo: true,
+          originalLang: true,
           answer: true,
+          answerEn: true,
           status: true,
           createdAt: true,
           updatedAt: true,
@@ -57,6 +61,12 @@ router.patch(
       return res.status(400).json({ message: "Invalid status" });
     }
 
+    const existing = await prisma.support.findUnique({
+      where: { id },
+      select: { id: true, originalLang: true },
+    });
+    if (!existing) return res.status(404).json({ message: "Not found" });
+
     const data: Record<string, any> = {};
 
     if (answer !== undefined) {
@@ -65,6 +75,15 @@ router.patch(
         data.status = "ANSWERED";
       }
       data.answeredAt = answer ? new Date() : null;
+      if (answer && existing.originalLang === "EN") {
+        try {
+          data.answerEn = await translateText(answer, "EN");
+        } catch (e) {
+          data.answerEn = null;
+        }
+      } else if (answer && existing.originalLang === "KO") {
+        data.answerEn = null;
+      }
     }
 
     if (status !== undefined) {
@@ -82,7 +101,10 @@ router.patch(
         userId: true,
         name: true,
         question: true,
+        questionKo: true,
+        originalLang: true,
         answer: true,
+        answerEn: true,
         status: true,
         createdAt: true,
         updatedAt: true,

--- a/src/api/support.ts
+++ b/src/api/support.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { asyncHandler } from "../utils/asyncHandler";
 import { authToken } from "../middlewares/authMiddleware";
 import { PrismaClient } from "@prisma/client";
+import { detectLanguage, translateText } from "../utils/deepl";
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -17,8 +18,27 @@ router.post(
     if (!name || !question)
       return res.status(400).json({ message: "Missing fields" });
 
+    const lang = await detectLanguage(question);
+
+    let questionKo: string | null = null;
+    if (lang === "EN") {
+      try {
+        questionKo = await translateText(question, "KO");
+      } catch (e) {
+        questionKo = question;
+      }
+    } else {
+      questionKo = question;
+    }
+
     const support = await prisma.support.create({
-      data: { userId, name, question },
+      data: {
+        userId,
+        name: String(name).trim(),
+        question: String(question).trim(),
+        questionKo,
+        originalLang: lang,
+      },
     });
     res.status(201).json(support);
   })

--- a/src/api/support.ts
+++ b/src/api/support.ts
@@ -64,7 +64,9 @@ router.get(
           id: true,
           name: true,
           question: true,
+          originalLang: true,
           answer: true,
+          answerEn: true,
           status: true,
           createdAt: true,
           updatedAt: true,
@@ -74,7 +76,19 @@ router.get(
       prisma.support.count({ where: { userId } }),
     ]);
 
-    res.json({ items, total, page, pageSize });
+    const mapped = await Promise.all(
+      items.map(async (it) => {
+        if (it.originalLang === "EN") {
+          const answerForUser =
+            it.answerEn ??
+            (it.answer ? await translateText(it.answer, "EN") : null);
+          return { ...it, answerForUser };
+        }
+        return { ...it, answerForUser: it.answer ?? null };
+      })
+    );
+
+    res.json({ items: mapped, total, page, pageSize });
   })
 );
 


### PR DESCRIPTION
# Pull Request

## Description
This PR adds multilingual support for user inquiries and admin answers by introducing translation-aware fields and API behavior.

### What’s Changed
- DB/Prisma
  - Added fields to Support model:
    - questionKo String? — Korean translation (admin-facing)
    - originalLang String? — detected source language (e.g., "EN" | "KO")
    - answerEn String? — English translation of admin’s answer (user-facing when original was EN)
  - Migration: support_add_translation_fields (e.g., npx prisma migrate dev -n "support_add_translation_fields")
- Server (Support – user endpoints)
  - POST /support
    - Detects language via detectLanguage(question)
    - If EN, translates to KO with translateText(question, "KO") and stores in questionKo
    - Saves originalLang ("EN"/"KO")
  - GET /support/my & GET /support/:id
    - Includes originalLang, questionKo, and answerEn in select
    - (Front-end can show answerEn to EN users, answer to KO users)
- Server (Admin – support endpoints)
  - GET /admin/support
    - Includes questionKo, originalLang, and answerEn for admin UI
    - Admin UI should display questionKo ?? question by default
  - PATCH /admin/support/:id
    - When admin saves answer and the ticket’s originalLang === "EN", generates and stores answerEn = translateText(answer, "EN")
    - Maintains existing status/answeredAt auto-update logic

## Why
- Admin readability: Regardless of the user’s language, admins can read a Korean version of the question.
- User experience: If the user asked in English, they will see the English version of the admin’s answer.
- Performance & consistency: Caches translations in DB (questionKo, answerEn) to avoid repeated external API calls and ensure consistent display across clients.

## Testing
1. Prepare
  - Set DEEPL_API_KEY in .env
  - Run npx prisma migrate dev -n "support_add_translation_fields"
  - Restart server
2. Create (EN question)
  - POST /support with {"name":"Test","question":"Hello, I need help with my booking."}
  - ✅ DB: originalLang = "EN", questionKo is populated (Korean), question stores original English
3. Admin reads list
  - GET /admin/support
  - ✅ Response includes questionKo, originalLang (UI shows questionKo ?? question)
4. Admin answers (KO)
  - PATCH /admin/support/:id with {"answer":"문의 감사합니다. 예약 정보를 확인했습니다.","status":"ANSWERED"}
  - ✅ DB: answer saved; because originalLang === "EN", answerEn is populated with English translation; answeredAt set
5. User reads
  - GET /support/my or GET /support/:id
  - ✅ If originalLang === "EN", response includes answerEn and front-end shows English answer; otherwise shows answer (Korean)
6. KO question path
  - Create with Korean question
  - ✅ originalLang = "KO", questionKo equals original, answerEn remains null

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [ ] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
