### PR TITLE
Fix/news and events

### DIFF
--- a/prisma/migrations/20250818123444_news_add_created_at_with_id/migration.sql
+++ b/prisma/migrations/20250818123444_news_add_created_at_with_id/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "News_createdAt_id_idx" ON "News"("createdAt", "id");

--- a/prisma/migrations/20250818124716_events_add_created_at_with_id/migration.sql
+++ b/prisma/migrations/20250818124716_events_add_created_at_with_id/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Event_createdAt_id_idx" ON "Event"("createdAt", "id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -375,6 +375,8 @@ model Event {
   contentEn String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([createdAt, id])
 }
 
 model Support {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -363,6 +363,8 @@ model News {
   contentEn String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([createdAt, id])
 }
 
 model Event {

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -39,4 +39,51 @@ router.get(
   })
 );
 
+router.get(
+  "/:id/adjacent",
+  asyncHandler(async (req, res) => {
+    const id = Number(req.params.id);
+
+    const current = await prisma.event.findUnique({
+      where: { id },
+      select: { id: true, createdAt: true },
+    });
+    if (!current) return res.status(404).json({ message: "Event not found" });
+
+    const prev = await prisma.event.findFirst({
+      where: {
+        OR: [
+          { createdAt: { gt: current.createdAt } },
+          { createdAt: current.createdAt, id: { gt: current.id } },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        titleEn: true,
+        createdAt: true,
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+
+    const next = await prisma.event.findFirst({
+      where: {
+        OR: [
+          { createdAt: { lt: current.createdAt } },
+          { createdAt: current.createdAt, id: { lt: current.id } },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        titleEn: true,
+        createdAt: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+
+    res.json({ prev, next });
+  })
+);
+
 export default router;

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -39,4 +39,51 @@ router.get(
   })
 );
 
+router.get(
+  "/:id/adjacent",
+  asyncHandler(async (req, res) => {
+    const id = Number(req.params.id);
+
+    const current = await prisma.news.findUnique({
+      where: { id },
+      select: { id: true, createdAt: true },
+    });
+    if (!current) return res.status(404).json({ message: "News not found" });
+
+    const prev = await prisma.news.findFirst({
+      where: {
+        OR: [
+          { createdAt: { gt: current.createdAt } },
+          { createdAt: current.createdAt, id: { gt: current.id } },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        titleEn: true,
+        createdAt: true,
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+
+    const next = await prisma.news.findFirst({
+      where: {
+        OR: [
+          { createdAt: { lt: current.createdAt } },
+          { createdAt: current.createdAt, id: { lt: current.id } },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        titleEn: true,
+        createdAt: true,
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+
+    res.json({ prev, next });
+  })
+);
+
 export default router;


### PR DESCRIPTION
# Pull Request

## Description
- Backend
  - Implemented adjacent API for both news and events to fetch the previous and next item relative to the current detail view.
  - Added query logic using createdAt and id ordering to efficiently determine adjacent items.
- Database/Prisma
  - Updated Prisma schema for news and event models to include createdAt and id composite index (@@index([createdAt, id])) for optimized adjacent lookups.
  - Ensured that both models store createdAt timestamps for consistent ordering.

## Why
- Allows users to easily navigate between news and event detail pages without returning to the list.
- Improves user experience and engagement by showing adjacent articles/events directly.
- The composite index ensures better performance and scalability as the dataset grows.

## Testing
- Ran npx prisma migrate dev to apply schema changes.
- Verified /v1/news/:id/adjacent returns correct prev and next objects.
- Verified /v1/events/:id/adjacent returns correct prev and next objects.
- Checked DB to confirm createdAt values are populated and index is created.
- Tested locally in frontend to ensure navigation via adjacent API works correctly.

## Screenshots (if applicable)
<!-- 
Attach UI screenshots or logs if relevant.
-->

## Linked Issues
None

## Checklist
- [x] Code builds and runs locally
- [ ] All tests pass
- [x] New features are covered by tests (if applicable)
- [ ] I have updated documentation (if needed)
